### PR TITLE
Remove arbitrary offsets

### DIFF
--- a/dist/tidytree.js
+++ b/dist/tidytree.js
@@ -1388,6 +1388,16 @@ var TidyTree = (function () {
   TidyTree.validBranchColorModes = ["none", "monophyletic"]; // later, toRoot? 
 
   /**
+   * Private method to calculate how much vertical space to leave for the ruler
+   */
+  TidyTree.prototype._rulerOffset = function () {
+    return this.ruler &&
+      this.layout === "horizontal" &&
+      (this.type === 'weighted' || this.type === 'tree')
+      ? 25 : 0;
+  };
+
+  /**
    * Draws a Phylogenetic on the element referred to by selector
    * @param  {String} selector A CSS selector
    * @return {TidyTree}           the TidyTree object
@@ -1401,7 +1411,7 @@ var TidyTree = (function () {
     this.width =
       parseFloat(parent.style("width")) - this.margin[1] - this.margin[3];
     this.height =
-      parseFloat(parent.style("height")) - this.margin[0] - this.margin[2];
+      parseFloat(parent.style("height")) - this.margin[0] - this.margin[2] - this._rulerOffset();
 
     let tree = d3.tree();
 
@@ -1811,8 +1821,8 @@ var TidyTree = (function () {
   TidyTree.prototype.redraw = function () {
     let parent = this.parent;
 
-    this.width  = (parseFloat(parent.style("width" )) - this.margin[1] - this.margin[3]     ) * this.hStretch;
-    this.height = (parseFloat(parent.style("height")) - this.margin[0] - this.margin[2]     ) * this.vStretch;
+    this.width  = (parseFloat(parent.style("width" )) - this.margin[1] - this.margin[3]) * this.hStretch;
+    this.height = (parseFloat(parent.style("height")) - this.margin[0] - this.margin[2] - this._rulerOffset()) * this.vStretch;
 
     this.scalar =
       this.layout === "horizontal" ? this.width :

--- a/dist/tidytree.js
+++ b/dist/tidytree.js
@@ -1401,7 +1401,7 @@ var TidyTree = (function () {
     this.width =
       parseFloat(parent.style("width")) - this.margin[1] - this.margin[3];
     this.height =
-      parseFloat(parent.style("height")) - this.margin[0] - this.margin[2] - 25;
+      parseFloat(parent.style("height")) - this.margin[0] - this.margin[2];
 
     let tree = d3.tree();
 
@@ -1812,7 +1812,7 @@ var TidyTree = (function () {
     let parent = this.parent;
 
     this.width  = (parseFloat(parent.style("width" )) - this.margin[1] - this.margin[3]     ) * this.hStretch;
-    this.height = (parseFloat(parent.style("height")) - this.margin[0] - this.margin[2] - 25) * this.vStretch;
+    this.height = (parseFloat(parent.style("height")) - this.margin[0] - this.margin[2]     ) * this.vStretch;
 
     this.scalar =
       this.layout === "horizontal" ? this.width :

--- a/src/main.js
+++ b/src/main.js
@@ -132,7 +132,7 @@ TidyTree.prototype.draw = function (selector) {
   this.width =
     parseFloat(parent.style("width")) - this.margin[1] - this.margin[3];
   this.height =
-    parseFloat(parent.style("height")) - this.margin[0] - this.margin[2] - 25;
+    parseFloat(parent.style("height")) - this.margin[0] - this.margin[2];
 
   let tree = d3.tree();
 
@@ -543,7 +543,7 @@ TidyTree.prototype.redraw = function () {
   let parent = this.parent;
 
   this.width  = (parseFloat(parent.style("width" )) - this.margin[1] - this.margin[3]     ) * this.hStretch;
-  this.height = (parseFloat(parent.style("height")) - this.margin[0] - this.margin[2] - 25) * this.vStretch;
+  this.height = (parseFloat(parent.style("height")) - this.margin[0] - this.margin[2]     ) * this.vStretch;
 
   this.scalar =
     this.layout === "horizontal" ? this.width :

--- a/src/main.js
+++ b/src/main.js
@@ -119,6 +119,16 @@ TidyTree.validNodeColorModes = ["none", "predicate"]; // later, highlight on hov
 TidyTree.validBranchColorModes = ["none", "monophyletic"]; // later, toRoot? 
 
 /**
+ * Private method to calculate how much vertical space to leave for the ruler
+ */
+TidyTree.prototype._rulerOffset = function () {
+  return this.ruler &&
+    this.layout === "horizontal" &&
+    (this.type === 'weighted' || this.type === 'tree')
+    ? 25 : 0;
+}
+
+/**
  * Draws a Phylogenetic on the element referred to by selector
  * @param  {String} selector A CSS selector
  * @return {TidyTree}           the TidyTree object
@@ -132,7 +142,7 @@ TidyTree.prototype.draw = function (selector) {
   this.width =
     parseFloat(parent.style("width")) - this.margin[1] - this.margin[3];
   this.height =
-    parseFloat(parent.style("height")) - this.margin[0] - this.margin[2];
+    parseFloat(parent.style("height")) - this.margin[0] - this.margin[2] - this._rulerOffset();
 
   let tree = d3.tree();
 
@@ -542,8 +552,8 @@ function labeler(d) {
 TidyTree.prototype.redraw = function () {
   let parent = this.parent;
 
-  this.width  = (parseFloat(parent.style("width" )) - this.margin[1] - this.margin[3]     ) * this.hStretch;
-  this.height = (parseFloat(parent.style("height")) - this.margin[0] - this.margin[2]     ) * this.vStretch;
+  this.width  = (parseFloat(parent.style("width" )) - this.margin[1] - this.margin[3]) * this.hStretch;
+  this.height = (parseFloat(parent.style("height")) - this.margin[0] - this.margin[2] - this._rulerOffset()) * this.vStretch;
 
   this.scalar =
     this.layout === "horizontal" ? this.width :


### PR DESCRIPTION
Fixes #4 

Branches from #2 

There were a few arbitrary offsets of `25` subtracted from height calculations.

It's not clear why this was done. To leave space for a title? There doesn't seem to be a prop for that.

Ah... maybe it's for the ruler.
